### PR TITLE
Remove unsupported `const` declaration on local variable in graphlayout.jl

### DIFF
--- a/src/graphlayout.jl
+++ b/src/graphlayout.jl
@@ -13,7 +13,7 @@ export graphlayout, meshlayout
 #, meshlayout, shaded_graph, edgeweights_graph
 
 function gradientalg(f, df, epochs, x0)
-    const minstepsize = 1e-16
+    minstepsize = 1e-16
     eta = 0.05
     theta = x0
     oldrisk = f(theta)


### PR DESCRIPTION
I'm getting a compile error when trying to run Callisto. The error I get is:

```
Failed to precompile CallistoVisualization [4bf5cafc-e35d-4b43-8dcc-f87515cd361a] to /Users/chrispearce/.julia/compiled/v1.8/CallistoVisualization/jl_Et8opy.
ERROR: LoadError: syntax: unsupported `const` declaration on local variable around /Users/chrispearce/src/julia/PlotKit.jl/src/graphlayout.jl:16
```

Based on #5 this is a known issue?